### PR TITLE
Testing Patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
         pip install -U pytest
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
-        echo "y" | pip uninstall epispot
     - name: Build from source
       run: |
         python setup-nightly.py install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,4 +42,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test package source code for errors
       run: |
-        pytest
+        python -m pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         pip install -U pytest
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
+        pip uninstall epispot
     - name: Build from source
       run: |
         python setup-nightly.py install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         pip install -U pytest
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
-        pip uninstall epispot
+        echo "y" | pip uninstall epispot
     - name: Build from source
       run: |
         python setup-nightly.py install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,6 @@ jobs:
         pip install -U codecov
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
-        echo "y" | pip uninstall epispot
     - name: Build from source
       run: |
         python setup-nightly.py install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,8 @@ jobs:
         pip install -U coverage
         pip install -U codecov
         pip install -r requirements.txt
+        pip install -r bin/requirements.txt
+        pip uninstall epispot
     - name: Prepares Code Coverage Report 
       continue-on-error: true
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,9 @@ jobs:
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
         echo "y" | pip uninstall epispot
+    - name: Build from source
+      run: |
+        python setup-nightly.py install
     - name: Prepares Code Coverage Report 
       continue-on-error: true
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -U codecov
         pip install -r requirements.txt
         pip install -r bin/requirements.txt
-        pip uninstall epispot
+        echo "y" | pip uninstall epispot
     - name: Prepares Code Coverage Report 
       continue-on-error: true
       run: |

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,3 +1,2 @@
-epispot
 fire
 termcolor


### PR DESCRIPTION
# Fixes incorrect installation during tests
___

## Known Issues
This PR successfully solves the incorrect installation of `epispot` during tests.
It solves this by
1. removing the PyPI installation from `bin/requirements.txt` via a `pip uninstall epispot` command
2. runs `pytest` as a module to import epispot from `Namespace`
## Code Breakdown
 - .github/
     - build.yml
         - Changes testing script
     - coverage.yml
         - Changes testing script to be compatible with `build.yml`
## Additional Notes

Fixes #47 
