### PR TITLE
Pushes all documentation changes to `en/latest`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,16 +36,16 @@ jobs:
       continue-on-error: true
       run: |
         git add .
-        git commit -m "Stashed documentation changes"
-    - name: Set up gh-pages
+        git commit -m "Stashed Documentation Changes"
+    - name: Set up gh-pages  # See #34 for directory structure information
       run: |
         git checkout gh-pages
-        rm *.html
+        rm -rf en/latest/  # -rf to delete all subdirectories
     - name: Push docs to gh-pages
-      continue-on-error: true
+      continue-on-error: true  # Git will return an error if the working tree is clean (i.e. no modifications to the current documentation exist)
       run: |
         git checkout master stash1/
-        mv stash1/epispot/* .
+        mv stash1/epispot/* en/latest/
         git add .
         git commit -m "Updated Documentation"
         git push


### PR DESCRIPTION
Similar to most documentation pages and to account for multiple different translations and versions, epispot's main docs have been moved into a new directory `en/latest`. The directory paths will take the form of `[lang code]/[version tag]`. For translations, the `/latest` tag will redirect to the latest translated version docs available. Additionally, an empty URL specifying no directory will automatically redirect to the `en/latest` documentation to avoid URL conflicts. Currently, however, no 404 page or redirection exists on the `gh-pages` branch.

## Additional Notes
Fixes #34 
