### PR TITLE
[Re] Patch 34

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
       continue-on-error: true  # Git will return an error if the working tree is clean (i.e. no modifications to the current documentation exist)
       run: |
         git checkout master stash1/
+        mkdir -p en/latest/  # recreate empty directory after being deleted in previous step
         mv stash1/epispot/* en/latest/
         git add .
         git commit -m "Updated Documentation"

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+pyvenv.cfg
 .env
 .venv
 env/


### PR DESCRIPTION
This PR is a follow-up to #59 which addresses an issue that was introduced into the `master` branch via that PR and solves the #34 issue. The old PR deleted `en/latest` and then re-used it which caused the automatic documentation process to stop without auto-updating the docs. This has now been fixed by recreating the folder every time (see commits). Additionally, it adds a new `venv` configuration to the `.gitignore` that was discovered via new tests.