### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,14 @@ before_install:
   - python -m pip install --upgrade pip  # Upgrade to latest version of pip
 
 install:
-  - pip install -r requirements-dev.txt  # Install all necessary development requirements
+  - pip install numpy
+  - pip install matplotlib
+  - pip install pandas
+  - pip install plotly
   - pip install SciencePlots
+  - pip install pytest
+  - pip install coverage
+  - pip install codecov
 
 script:
   - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
   - python -m pip install --upgrade pip  # Upgrade to latest version of pip
 
 install:
-  - pip install SciencePlots
   - pip install -r requirements-dev.txt  # Install all necessary development requirements
+  - pip install SciencePlots
 
 script:
   - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - python -m pip install --upgrade pip  # Upgrade to latest version of pip
 
 install:
+  - pip install SciencePlots
   - pip install -r requirements-dev.txt  # Install all necessary development requirements
 
 script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest
 coverage
 codecov
 pdoc3
+SciencePlots

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ numpy
 fire
 pandas
 plotly
-SciencePlots
 pytest
 coverage
 codecov


### PR DESCRIPTION
The bug in the Travis CI code happens because we install SciencePlots and matplotlib at the same time, so when SciencePlots tries to install the styles to matplotlib, it errors as there is no way to install them into matplotlib, which hasn't been installed.

## Solution
We first install all the developer requirements, which no longer include SciencePlots, and then separately, we install SciencePlots. 