### PR TITLE
Fix #68, LGTM PR #67 'unused variable' alerts

### DIFF
--- a/epispot/plots/native.py
+++ b/epispot/plots/native.py
@@ -30,7 +30,7 @@ plt.style.use(['science', 'no-latex'])  # default style
 
 
 def model(Model, time_frame, title='Compartment Populations over Time', 
-          starting_state=None, compartments=None, names=None, show_susceptible=False, 
+          starting_state=None, names=None, show_susceptible=False, 
           log=False, latex=True):
     """
     Plots the results of one model using `matplotlib`.
@@ -44,8 +44,6 @@ def model(Model, time_frame, title='Compartment Populations over Time',
     - time_frame: A `range()` describing the time period to plot
     - title: (`='Compartment Populations over Time`) The title of the plot
     - starting_state: (default:inherited) Initial model state (see `epispot.models.Model.integrate` parameter `starting_state`)
-    - compartments: (default:all) The indices of the compartments in the model to plot; 
-                    all other compartments will be hidden
     - names: (default:`Model.layer_names`) A list of names for each of the compartments
     - show_susceptible: (`=False`) Boolean value describing whether or not to plot the Susceptible compartment.\
                                    **This assumes that the Susceptible compartment is the first in `Model`**\
@@ -65,9 +63,6 @@ def model(Model, time_frame, title='Compartment Populations over Time',
     System = Model.integrate(time_frame, starting_state=starting_state)
 
     # parameter substitutions
-    if compartments is None:
-        compartments = list(range(len(Model.layers)))
-
     if names is None:
         names = Model.layer_names
 
@@ -79,16 +74,11 @@ def model(Model, time_frame, title='Compartment Populations over Time',
         for i, compartment in enumerate(day):
             DataFrame[Model.layer_names[i]].append(compartment)
 
-    if not show_susceptible:
-        for i, compartment in enumerate(compartments):
-            if compartment == 0:
-                del compartments[i]
-                break
-
     # plotting
     plt.figure(figsize=(9, 5))
-    for compartment in compartments:
-        plt.plot(time_frame, DataFrame[Model.layer_names[compartment]], label=names[compartment])
+    for compartment, _ in enumerate(Model.layers):
+        if (not show_susceptible and compartment != 0) or show_susceptible:
+            plt.plot(time_frame, DataFrame[Model.layer_names[compartment]], label=names[compartment])
 
     if log:
         plt.yscale('log')

--- a/epispot/plots/web.py
+++ b/epispot/plots/web.py
@@ -16,7 +16,7 @@ from . import px
 
 
 def model(Model, time_frame, title='Compartment Populations over Time', 
-          starting_state=None, compartments=None, names=None, show_susceptible=False, 
+          starting_state=None, names=None, show_susceptible=False, 
           log=False, colors=None):
     """
     Plots the results of one model using `plotly`.
@@ -28,8 +28,6 @@ def model(Model, time_frame, title='Compartment Populations over Time',
     - time_frame: A `range()` describing the time period to plot
     - title: (`='Compartment Populations over Time`) The title of the plot
     - starting_state: (default:inherited) Initial model state (see `epispot.models.Model.integrate` parameter `starting_state`)
-    - compartments: (default:all) The indices of the compartments in the model to plot; 
-                    all other compartments will be hidden
     - names: (default:`Model.layer_names`) A list of names for each of the compartments (**cannot be `'index'` or `'value'`**)
     - show_susceptible: (`=False`) Boolean value describing whether or not to plot the Susceptible compartment.\
                                    **This assumes that the Susceptible compartment is the first in `Model`**\
@@ -46,9 +44,6 @@ def model(Model, time_frame, title='Compartment Populations over Time',
     System = Model.integrate(time_frame, starting_state=starting_state)
     
     # parameter substitutions
-    if compartments is None:
-        compartments = range(len(Model.layers))
-    
     if names is None:
         names = Model.layer_names
     
@@ -95,7 +90,7 @@ def model(Model, time_frame, title='Compartment Populations over Time',
 
 
 def stacked(Model, time_frame, title='Compartment Populations over Time', 
-            starting_state=None, compartments=None, names=None, show_susceptible=False, 
+            starting_state=None, names=None, show_susceptible=False, 
             log=False, colors=None):
     """
     Plots the results of one model using `plotly` as a stacked area chart.
@@ -107,8 +102,6 @@ def stacked(Model, time_frame, title='Compartment Populations over Time',
     - time_frame: A `range()` describing the time period to plot
     - title: (`='Compartment Populations over Time`) The title of the plot
     - starting_state: (default:inherited) Initial model state (see `epispot.models.Model.integrate` parameter `starting_state`)
-    - compartments: (default:all) The indices of the compartments in the model to plot; 
-                    all other compartments will be hidden
     - names: (default:`Model.layer_names`) A list of names for each of the compartments (**cannot be `'index'` or `'value'`**)
     - show_susceptible: (`=False`) Boolean value describing whether or not to plot the Susceptible compartment.\
                                    **This assumes that the Susceptible compartment is the first in `Model`**\
@@ -125,9 +118,6 @@ def stacked(Model, time_frame, title='Compartment Populations over Time',
     System = Model.integrate(time_frame, starting_state=starting_state)
 
     # parameter substitutions
-    if compartments is None:
-        compartments = range(len(Model.layers))
-
     if names is None:
         names = Model.layer_names
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -64,14 +64,13 @@ def test_plain_web():
 def test_full_web():
     """In-browser plotting test (all parameters)"""
     Model = epi.pre.SEIR(R_0, N, place, gamma, delta)  # compile model
-    Figure = epi.plots.web.model(Model, range(120), 
+    Figure = epi.plots.web.model(Model, range(120),
                                  title='SEIR Model Plot',
-                                 starting_state=[N(0) - 10, 10, 0], 
-                                 compartments=[0, 1, 2], 
-                                 names=['Susceptible', 'Pre-infection', 'Infection'], 
-                                 show_susceptible=True, 
-                                 log=True, 
-                                 colors=['red', 'green', 'blue']
+                                 starting_state=[N(0) - 10, 10, 0, 0],
+                                 names=['Susceptible', 'Pre-infection', 'Infection', 'Recovered/Removed'],
+                                 show_susceptible=True,
+                                 log=True,
+                                 colors=['red', 'green', 'blue', 'purple']
                                  )
     return Figure
 
@@ -87,14 +86,13 @@ def test_full_stacked():
     """In-browser plotting test for stacked area charts (all parameters)"""
     Model = epi.pre.SEIR(R_0, N, place, gamma, delta)  # compile model
     Figure = epi.plots.web.stacked(Model, range(120),
-                                 title='SEIR Model Plot',
-                                 starting_state=[N(0) - 10, 10, 0],
-                                 compartments=[0, 1, 2],
-                                 names=['Susceptible', 'Pre-infection', 'Infection'],
-                                 show_susceptible=True,
-                                 log=True,
-                                 colors=['red', 'green', 'blue']
-                                 )
+                                   title='SEIR Model Plot',
+                                   starting_state=[N(0) - 10, 10, 0, 0],
+                                   names=['Susceptible', 'Pre-infection', 'Infection', 'Recovered/Removed'],
+                                   show_susceptible=True,
+                                   log=True,
+                                   colors=['red', 'green', 'blue', 'purple']
+                                   )
     return Figure
 
 
@@ -109,14 +107,13 @@ def test_full_native():
     """Native plotting test (all parameters)"""
     Model = epi.pre.SEIR(R_0, N, place, gamma, delta)  # compile model
     #`latex=True` enabled by default
-    # blank strings `''` in `names=` are used to indicate that 
+    # blank strings `''` in `names=` are used to indicate that
     # the corresponding compartment is not being plotted
-    Figure = epi.plots.native.model(Model, range(120), 
-                                    title='SEIR Model Plot', 
-                                    starting_state=[N(0) - 50, 25, 25, 0], 
-                                    compartments=[0, 3], 
-                                    names=['Susceptible Population', '', '', 'Removed/Recovered'], 
-                                    show_susceptible=True, 
+    Figure = epi.plots.native.model(Model, range(120),
+                                    title='SEIR Model Plot',
+                                    starting_state=[N(0) - 50, 25, 25, 0],
+                                    names=['Susceptible Population','Pre-Infection', 'Infection', 'Removed/Recovered'],
+                                    show_susceptible=True,
                                     log=True)
     return Figure
 
@@ -135,10 +132,10 @@ def test_full_native_stack():
     # blank strings `''` in `names=` are used to indicate that
     # the corresponding compartment is not being plotted
     Figure = epi.plots.native.stacked(Model, range(120),
-                                    title='SEIR Model Plot',
-                                    starting_state=[N(0) - 50, 25, 25, 0],
-                                    compartments=[0, 3],
-                                    names=['Susceptible Population', '', '', 'Removed/Recovered'],
-                                    show_susceptible=True,
-                                    log=True)
+                                      title='SEIR Model Plot',
+                                      starting_state=[N(0) - 50, 25, 25, 0],
+                                      compartments=[0, 3],
+                                      names=['Susceptible Population', 'Pre-Infection', 'Infection', 'Removed/Recovered'],
+                                      show_susceptible=True,
+                                      log=True)
     return Figure


### PR DESCRIPTION
This commit fixes the issues described in "Improper handling of `compartments` parameter in `massive-plots`" (#68), which also reappear in 2 'unused variable' alerts on LGTM for PR #67. These can be seen at https://lgtm.com/projects/g/epispot/epispot/rev/pr-4a4c33bcfb0a25433ea10477d7c49b516a6f75d6. Additionally, this commit removes all `compartment` parameters where they are not necessary because similar functionality is already provided by the graphics engine.

Changelist:
- Remove `compartments` from and restructure `epi.plots.native.model()`
- Remove all `compartments` from functions in `epi.plots.web`
- Edit `tests/plotting::*full*` to run tests without `compartments` specifications

Additional Notes:
Fixes (major):
Fix #68 
Fix 2 LGTM 'unused variable` alerts in `epi.plots.web` for PR #67 