### PR TITLE
Deploy v3.0.0-alpha-1 (trial: 1)

### DIFF
--- a/setup-nightly.py
+++ b/setup-nightly.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "Documentation": "https://epispot.github.io/epispot",
         "Code Coverage": "https://app.codecov.io/gh/epispot/epispot"
     },
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages('epispot/'),
     scripts=['bin/epispot'],
     classifiers=[
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "Documentation": "https://epispot.github.io/epispot",
         "Code Coverage": "https://app.codecov.io/gh/epispot/epispot"
     },
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages('epispot/'),
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
This PR makes setup-nightly.py installable. By merging this PR, `master` will be up-to-date with all the commits from `v3.0.0-alpha`. However, we may want to make a similar change to setup.py before merging this. @Quantalabs will head the review process to answer this question and determine if there are any more adjustments we need to make.