### PR TITLE
Remove scope from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     commit-message:
       prefix: "[dep]"
       prefix-development: "[dep/dev]"
-      include: "scope"
     labels:
       - "dependencies"
       - "low priority :arrow_down_small:"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
       prefix-development: "[dep/dev]"
     labels:
       - "dependencies"
-      - "low priority :arrow_down_small:"
+      - "low-priority :arrow_down_small:"
       - "unsupported :no_entry:"
     


### PR DESCRIPTION
This PR removes the scope from the dependabot - this prevents the [dep](deps) prefix for PRs - and fixes the label problem, which could not load the `low priority 🔽` label for PRs.