### PR TITLE
Prepare release of v3.0.0-alpha-2

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -16,4 +16,4 @@ name = "python"
 enabled = true
 
   [analyzers.meta]
-  runtime_version = "3.x.x"
+  runtime_version = "3.9.6"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -14,6 +14,11 @@ exclude_patterns = [
 [[analyzers]]
 name = "python"
 enabled = true
+dependency_file_paths = [
+    "requirements/requirements.txt",
+    "requirements/requirements-nightly.txt",
+    "requirements/requirements-dev.txt"
+]
 
   [analyzers.meta]
-  runtime_version = "3.9.6"
+  runtime_version = "3.x.x"

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -36,6 +36,8 @@ exe
 explorables
 figsize
 Froese
+func
+funcs
 gitbook
 github
 gitignore

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,6 +1,8 @@
 argv
 autobuild
 backend
+bugfix
+bugfixes
 cfg
 changelog
 CLIs
@@ -24,6 +26,7 @@ currentdir
 deepcopy
 deepsource
 dep
+Dependabot
 deps
 dirname
 Django

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -11,6 +11,7 @@ hos
 isinstance
 len
 Phy
+pletely
 sdist
 SIHCR
 SIHRD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,39 @@
 # Release Notes
 
-Latest stable release: 2.1.1
+Latest stable release: 2.1.1\
+Latest nightly release: 2.1.1.15\
+Latest alpha release: 3.0.0-alpha-2
 
 Releases are listed from most recent to least recent. All `alpha` and in-development versions are released to the [epispot-nightly](https://pypi.org/project/epispot-nightly/) project while all other releases are shipped to the [main project](https://pypi.org/project/epispot/).
 
 ---
+
+## Version Support
+
+Below is the official list of epispot versions and their support status. If we plan on deprecating a version, there will be a note next to the version listing a date (or approximate date) for when the version will be officially unsupported.
+
+| Version | Patch | Development | Bugfix | Security | Notes |
+| ------- | ------------ | ----------- | ------ | -------- | ----- |
+| 2.1   | 2.1.1 | :x: | ✔️ | ✔️ | Latest stable release |
+| 2.0   | 2.0.2 | :x: | ✔️ | ✔️ |
+| <= 1.1   | 1.1.0 | :x: | :x: | :x: | **Deprecated** |
+| nightly latest   | 2.1.1.x | :x: | :x: | ✔️ |
+| 3.0.0-alpha | 3.0.0a2 | ✔️ | ✔️ | ✔️ | Supported until stable release of v3 |
+| nightly < latest  | 2.1.1.x | :x: | :x: | :x: | **Deprecated** |
+
+---
+
+## 3.0.0-alpha-2 (standard-params)
+
+This is the second stage of the v3 release rollout, following [v3.0.0-alpha-1](#300-alpha-1-massive-plots). The major change in this release revolves around solving issue [#73](https://github.com/epispot/epispot/issues/73), which completely redesigns epispot's internals.
+
+In deprecations, we are now officially deprecating the entire `epispot.fitters` module. These changes have been reflected in our [updated documentation](https://epispot.github.io/epispot/en/v3.0.0-alpha-2/fitters.html). New alternatives are expected to arrive soon. Additionally, we've made the decision to officially end support for Python 3.6, following its removal from our testing suite and manifest files (including, finally, `setup.cfg`).
+
+The big news here, of course, are the huge changes to epispot's `Model` and `Compartment` objects. In short, `epispot.models` and `epispot.comps` have been completely redesigned so that each compartment in `epispot.comps` is a sub-compartment of a `Compartment` object, allowing you to create your own custom compartments. Additionally, models now accept the parameters and pass them on to compartments, instead of the other way around. This change is huge and is a large deprecation, so there is a lot to cover. We strongly recommend you read more about this change [here](https://github.com/epispot/epispot/issues/73) or read the new docs.
+
+In minor updates, we've [added support for Dependabot](https://github.com/epispot/epispot/issues/79) and [bumped Numpy to 1.21.1](https://github.com/epispot/epispot/commit/2fb5eff59c3b9d77f22b6dd1f95d34a9ac1bce6c#diff-9a3d09936710783b0cc2e50f54f8cc456be41c432647337fcf9a9391a9e81b98), featuring small performance improvements on the 1.21.0 release. In fact, there's now a `pre-requirements.txt` file to aid manual installation of the epispot package. Additionally, we've [added spellcheck as a routine CI/CD procedure](https://github.com/epispot/epispot/pull/92) on epispot and ensured that our new versions are typo-free. Speaking of CI/CD, we've officially [made the switch *back* from Travis CI to GitHub Actions](https://github.com/epispot/epispot/pull/93) which will give us faster build times and greater reliability. After the first v3 alpha release, we have now also [included alpha releases in our security policy](https://github.com/epispot/epispot/commit/43449d362eab94444a808fb6cedf6f04caee6cf0), so be sure to [check out the new security policy](https://github.com/epispot/epispot/blob/master/SECURITY.md).
+
+Finally, epispot now comes with a [new built-in sanity check](https://github.com/epispot/epispot/commit/71a70a040b8c60a77e038eb1edee0dda785798ef#diff-3bd065e1fc4a45ad5e94ee148eaf369a81d39db0c3ad4847b0d7323e4fe16a71), *but it won't run automatically*. This will hopefully increase performance by just a little bit since no checks are being run (unless they are manually invoked).
 
 ## 3.0.0-alpha-1 (massive-plots)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ The big news here, of course, are the huge changes to epispot's `Model` and `Com
 
 In minor updates, we've [added support for Dependabot](https://github.com/epispot/epispot/issues/79) and [bumped Numpy to 1.21.1](https://github.com/epispot/epispot/commit/2fb5eff59c3b9d77f22b6dd1f95d34a9ac1bce6c#diff-9a3d09936710783b0cc2e50f54f8cc456be41c432647337fcf9a9391a9e81b98), featuring small performance improvements on the 1.21.0 release. In fact, there's now a `pre-requirements.txt` file to aid manual installation of the epispot package. Additionally, we've [added spellcheck as a routine CI/CD procedure](https://github.com/epispot/epispot/pull/92) on epispot and ensured that our new versions are typo-free. Speaking of CI/CD, we've officially [made the switch *back* from Travis CI to GitHub Actions](https://github.com/epispot/epispot/pull/93) which will give us faster build times and greater reliability. After the first v3 alpha release, we have now also [included alpha releases in our security policy](https://github.com/epispot/epispot/commit/43449d362eab94444a808fb6cedf6f04caee6cf0), so be sure to [check out the new security policy](https://github.com/epispot/epispot/blob/master/SECURITY.md).
 
-Finally, epispot now comes with a [new built-in sanity check](https://github.com/epispot/epispot/commit/71a70a040b8c60a77e038eb1edee0dda785798ef#diff-3bd065e1fc4a45ad5e94ee148eaf369a81d39db0c3ad4847b0d7323e4fe16a71), *but it won't run automatically*. This will hopefully increase performance by just a little bit since no checks are being run (unless they are manually invoked).
+Finally, epispot now comes with a
+[new built-in sanity check](https://github.com/epispot/epispot/commit/71a70a040b8c60a77e038eb1edee0dda785798ef#diff-3bd065e1fc4a45ad5e94ee148eaf369a81d39db0c3ad4847b0d7323e4fe16a71), <!-- spellcheck: disable -->
+*but it won't run automatically*. This will hopefully increase performance by just a little bit since no checks are being run (unless they are manually invoked).
 
 ## 3.0.0-alpha-1 (massive-plots)
 

--- a/README-nightly.md
+++ b/README-nightly.md
@@ -6,8 +6,8 @@
 
 A Python package for the mathematical modeling of infectious diseases via compartmental models. Originally designed for epidemiologists, epispot can be adapted for almost any type of modeling scenario.
 
-> This is a nightly version of epispot and may contain possibly unstable code.\
-> **Please see usage instructions prior to adding this project as a dependency**\
+> This is a nightly version of epispot and may contain possibly unstable code.  
+> **Please see usage instructions prior to adding this project as a dependency**  
 > If you prefer to use the stable version of epispot, please see
 > the [project on PyPI](https://pypi.org/project/epispot)
 
@@ -78,9 +78,10 @@ This is the hardest way to install `epispot-nightly` but it can be particularly 
 Clone the repository with:
 
 ```shell
-git clone https://github.com/epispot/epispot  # clone epispot/epispot
-cd epispot  # open project
-pip install -r requirements-nightly.txt  # install package requirements
+git clone https://github.com/epispot/epispot
+cd epispot/requirements
+pip install -r pre-requirements.txt  # helps avoid version conflicts
+pip install -r requirements-nightly.txt
 ```
 
 If you're planning on helping out in the development process, it will be  helpful to install a few extra requirements with:
@@ -111,16 +112,18 @@ Please also note that security updates are not provided on previous nightly vers
 
 ## Getting Started
 
-Make sure you are already familiar with [epispot](https://www.pypi.org/project/epispot). If not, you can find epispot's auto-generated documentation [here](https://epispot.github.io/epispot/). Additionally, we highly recommend reading the [epispot manual](https://epispot.gitbook.io) to get a better understanding of the documentation and how to use epispot.
+Make sure you are already familiar with [epispot](https://www.pypi.org/project/epispot). If not, continue reading the auto-generated documentation published to this site. Additionally, we highly recommend reading the [epispot manual](https://epispot.gitbook.io) to get a better understanding of the documentation and how to use epispot.
 
-## Statuses
+## Current Statuses
+
+Please note that these statuses reflect the most recent CI checks and are not related to this specific version. The following statuses show the progress of the current development.
 
 | Pipeline | Status |
 | --- | --- |
-| Travis CI | [![Build Status](https://www.travis-ci.com/epispot/epispot.svg?branch=master)](https://www.travis-ci.com/epispot/epispot) |
+| Build (3.7-3.9) | [![Build](https://github.com/epispot/epispot/actions/workflows/build.yml/badge.svg)](https://github.com/epispot/epispot/actions/workflows/build.yml) |
 | CodeCov | [![codecov](https://codecov.io/gh/epispot/epispot/branch/master/graph/badge.svg?token=WGIM127RFY)](https://codecov.io/gh/epispot/epispot) |
-| PyPI main | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot.svg?color=success) |
-| PyPI nightly | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot-nightly.svg?color=success) |
+| PyPI main (latest) | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot.svg?color=success) |
+| PyPI nightly (latest) | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot-nightly.svg?color=success) |
 | Security | ![GitHub issue custom search in repo](https://img.shields.io/github/issues-search/epispot/epispot?color=success&label=known%20vulnerabilities&query=VULNERABILITY%20is:open%20is:issue) |
 
 ## Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,24 @@
 # Security Policy
 
 ## Supported Versions
+
 The following versions will receive regular security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
 | master-latest   | ✔️ |
 | master-2.x.x   | ✔️ |
+| nightly-alpha-latest   | ✔️ |
 | nightly-latest   | ✔️ |
 | master < 2.0   | :x: |
 | nightly < latest   | :x: |
 
 ## Reporting a Vulnerability
 
-The epispot team works as hard as possible to keep code clear of any vulnerabilities. 
-Our steps include extensive CodeQL analysis, third-party open-source code analysis from tools like codefactor.io, and heavy unit testing.
-However, vulnerabilities will inevitably arise. If you see or suspect a vulnerability, epispot will fix it as fast as possible.
+The epispot team works as hard as possible to keep code clear of any vulnerabilities. Our steps include extensive CodeQL analysis, third-party open-source code analysis from tools like DeepSource, and heavy unit testing. However, vulnerabilities will inevitably arise. If you see or suspect a vulnerability, epispot will fix it as fast as possible.
 
 ### Here's what to do if you've found a vulnerability:
+
 1. Open an issue and **@mention** a maintainer
 2. Title the issue "VULNERABILITY" but do not describe the vulnerability in the issue itself
 3. You will receive further instructions after completing (2)

--- a/epispot/__init__.py
+++ b/epispot/__init__.py
@@ -53,7 +53,7 @@ def _check_versions():
     """Checks for version conflicts"""
     pass
 
-def _check_install():
+def _check_install():  # pragma: no cover
     """Checks for installation errors"""
     pass
 
@@ -71,14 +71,14 @@ def sanity_check():
     
     """
     # check for installation errors
-    if not source or not version:
+    if not source or not version:  # pragma: no cover
         _check_install()
 
     # check for version conflicts
     import sys
     if (sys.version_info[0] < 3) or \
        (sys.version_info[0] == 3 and sys.version_info[1] < 7):
-        raise RuntimeError('Epispot requires Python 3.7 or later') # pragma: no cover
+        raise RuntimeError('Epispot requires Python 3.7 or later')  # pragma: no cover
     else:
         _check_versions()
 

--- a/epispot/__init__.py
+++ b/epispot/__init__.py
@@ -77,10 +77,9 @@ def sanity_check():
     # check for version conflicts
     import sys
     if (sys.version_info[0] < 3) or \
-       (sys.version_info[0] == 3 and sys.version_info[1] < 7):
+           (sys.version_info[0] == 3 and sys.version_info[1] < 7):
         raise RuntimeError('Epispot requires Python 3.7 or later')  # pragma: no cover
-    else:
-        _check_versions()
+    _check_versions()
 
     # check for updates
     _check_updates()

--- a/epispot/__init__.py
+++ b/epispot/__init__.py
@@ -2,7 +2,7 @@
 .. include:: ../README.md
 <!-- 
 Documentation available at: 
-https://epispot.github.io/epispot/en/v3.0.0-alpha-1 
+https://epispot.github.io/epispot/en/v3.0.0-alpha-2 
 -->
 """
 
@@ -48,70 +48,73 @@ from . import fitters
 from . import plots
 
 
-def _sanity_check():
-    """Pre-defined sanity check to check for installation errors"""
+# helper funcs
+def _check_versions():
+    """Checks for version conflicts"""
+    pass
 
-    if not version or not source:  # pragma: no cover
-        message = \
-        '''
-        Version information and/or source for your epispot installation could not be found.
-        This likely means
-         (1) this version of epispot is deprecated or dated
-         (2) your installation of epispot is unstable
-        Try reinstalling epispot
-         (1) From PyPI:
-             $ pip install epispot
-         (2) From Anaconda:
-             $ conda config --add channels conda-forge
-             $ conda install -c conda-forge epispot
-         (3) From the GitHub Source:
-             $ git clone https://github.com/epispot/epispot
-             $ cd epispot
-             $ python install setup-nightly.py
-        If this fails or has failed before, then revert to epispot's last stable version.
-        Again, you can do this via
-         (1) PyPI:
-             (a) Go to https://pypi.org/project/epispot
-             (b) Scroll to the last MAJOR release in the form `a.0.0`
-             (c) Install via `$ pip install epispot==a.0.0` -- replace `a` with version #
-         (2) GitHub Source:
-             (a) Go to https://github.com/epispot/epispot
-             (b) Click the 'branches' tab
-             (c) Select the last branch with name `vA.0.0` for some version number A
-             (d) Install as `.zip`
-             (e) Unzip
-             (f) Run `$ python install setup.py`
-        '''
-        raise DeprecationWarning(message)
+def _check_install():
+    """Checks for installation errors"""
+    pass
+
+def _check_updates():
+    """Checks for updates"""
+    pass
+
+def sanity_check():
+    """
+    Sanity check to check for basic installation errors, 
+    version conflicts, upgrades, etc.
+
+    **Run this if you experience any problems with epispot and before 
+    submitting any issues**
+    
+    """
+    # check for installation errors
+    if not source or not version:
+        _check_install()
+
+    # check for version conflicts
+    import sys
+    if (sys.version_info[0] < 3) or \
+       (sys.version_info[0] == 3 and sys.version_info[1] < 7):
+        raise RuntimeError('Epispot requires Python 3.7 or later') # pragma: no cover
+    else:
+        _check_versions()
+
+    # check for updates
+    _check_updates()
 
 
 # version info
-version = '3.0.0-alpha-1'
+version = '3.0.0-alpha-2'
 """
-Epispot's version info (updated every nightly release)
-Get with:
+Epispot's version info (updated every release)\n
+Check version information with:
 
 ```
     >>> print(epispot.version)
 ```
+
+Version information is also available through the `__version__` 
+property, included for legacy support.
 """
+__version__ = version  # alias for version
 
 stable = False
 """
 Build stability:
 
-- True → main package (stable)
-- False → nightly package (possibly unstable)
+- True ⇒ main package (stable)
+- False ⇒ nightly package (possibly unstable)
 """
 
 # metadata
 source = 'https://www.github.com/epispot/epispot'
-"""URL to GitHub source"""
-docs = 'https://epispot.github.io/epispot'
-"""Project documentation (not version-specific)"""
+"""URL to VCS source"""
+raw = f'https://raw.githubusercontent.com/epispot/epispot/v{version}/'
+"""URL to raw VCS source (must append file path)"""
+docs = f'https://epispot.github.io/epispot/en/v{version}/'
+"""Project documentation (version-specific)"""
 issues = 'https://www.github.com/epispot/epispot/issues'
-"""Submit new issues or bugs here"""
-
-
-_sanity_check()  # complete installation
-del _sanity_check
+"""Bug tracker"""

--- a/epispot/fitters.py
+++ b/epispot/fitters.py
@@ -15,6 +15,10 @@ def grad_des(get_model_pred, real_data,
              N, samples, delta=0.0001,
              verbose=False):  # pragma: no cover
     """
+    .. warning::
+       This function is currently deprecated.
+       Fixes will be added in future alpha releases.
+
     The gradient descent fitter. This is not stochastic.
     For long timespans, this may take a long time to converge.
 
@@ -98,6 +102,10 @@ def tree_search(get_model_pred, real_data,
                 epochs, N, samples,
                 verbose=False):  # pragma: no cover
     """
+    .. warning::
+       This function is currently deprecated.
+       Fixes will be added in future alpha releases.
+
     Note: This is an experimental fitter
     """
 

--- a/setup-nightly.py
+++ b/setup-nightly.py
@@ -5,7 +5,7 @@ with open("README-nightly.md", "r") as fh:
 
 setuptools.setup(
     name="epispot-nightly",
-    version="3.0.0-alpha-1",
+    version="3.0.0-alpha-2",
     author="quantum9innovation",
     description="The nightly version of the epispot package.",
     long_description=long_description,
@@ -31,5 +31,11 @@ setuptools.setup(
         "Topic :: Scientific/Engineering",
     ],
     python_requires='>=3.7',
-    install_requires=['matplotlib', 'numpy', 'fire', 'plotly'],
+    install_requires=[
+        'matplotlib~=3.4.2', 
+        'numpy~=1.21.1', 
+        'fire~=0.4.0', 
+        'plotly~=5.1.0',
+        'SciencePlots~=1.0.8'
+    ],
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 package_dir =
     = epispot
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 where = epispot

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -12,6 +12,7 @@ STRUCTURE:
 def test_base():
     """Triggers automatic import checks from within epispot"""
     import epispot
+    epispot.sanity_check()
 
 
 def test_integrity():


### PR DESCRIPTION
# Releasing v3.0.0-alpha-2
___

## New Feature
This PR focuses primarily on version bumps and file updates. The major changes are of course the bump to v3.0.0-alpha-2, preparing for the next alpha release, and the new release notes in the CHANGELOG. The other main feature is a new sanity check and more global variables to access data like version strings, documentation URLs, and more. The sanity check now is not run automatically, resulting in a small performance improvement.
## Known Issues
There are no known issues at this time (other than spellcheck, of course—this will be fixed soon).
## Code Breakdown
 - deepsource.toml
    - Upgrade analyzer runtime to a supported Python version
 - CHANGELOG.md
    - Add release notes for v3.0.0-alpha-2
 - README-nightly.md
    - Update from documentation
 - SECURITY.md
    - Add alpha releases to supported versions
    - Update codefactor.io to DeepSource
 - epispot/\_\_init\_\_.py
    - Add new sanity check
    - Add more global variables
    - Bring back support for `__version__`
 - epispot/fitters.py
    - Deprecate
 - setup-nightly.py
    - Bump version
    - Update requirements specs
 - setup.cfg
    - Update supported Python versions
 - tests/test_x.py
    - Test sanity checks manually
## Additional Notes
As this PR changes a lot of manifest files, @Quantalabs is going to lead the review process as code owner. We will need to merge this fast and then rebase the new changes onto the v3.0.0-alpha branch before deploying.

A full comparison with v3.0.0-alpha-1 can be found here:
https://github.com/epispot/epispot/compare/v3.0.0-alpha-1...v3a2
