### PR TITLE
SECURITY.md Revision 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,5 +78,6 @@ test_*              @quantum9innovation
 requirements-*      @Quantalabs
 
 LICENSE                 @quantum9innovation
+SECURITY.md             @quantum9innovation @Quantalabs
 setup.py                @Quantalabs
 setup-nightly.py        @Quantalabs

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -7,6 +7,9 @@
 // # no-spell-check.*$
 # marker for ignoring all lines with disabled spellcheck
 .*spellcheck: disable
+spellcheck: stop(.|\n)*spellcheck: start
+# ignore key blocks
+-----BEGIN PGP PUBLIC KEY BLOCK-----(.|\n)*-----END PGP PUBLIC KEY BLOCK-----
 
 # git index header
 index [0-9a-z]{7,40}\.\.[0-9a-z]{7,40}
@@ -14,6 +17,9 @@ index [0-9a-z]{7,40}\.\.[0-9a-z]{7,40}
 # data urls
 (['"])data:.*?\g{-1}
 data:[-a-zA-Z=;:/0-9+]*,\S*
+
+# Ignore @mentions and emails
+@.*
 
 # Any `http://` or `https://` URL
 https?://.*.com

--- a/README-nightly.md
+++ b/README-nightly.md
@@ -124,7 +124,6 @@ Please note that these statuses reflect the most recent CI checks and are not re
 | CodeCov | [![codecov](https://codecov.io/gh/epispot/epispot/branch/master/graph/badge.svg?token=WGIM127RFY)](https://codecov.io/gh/epispot/epispot) |
 | PyPI main (latest) | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot.svg?color=success) |
 | PyPI nightly (latest) | ![latest-release](https://shields.mitmproxy.org/pypi/v/epispot-nightly.svg?color=success) |
-| Security | ![GitHub issue custom search in repo](https://img.shields.io/github/issues-search/epispot/epispot?color=success&label=known%20vulnerabilities&query=VULNERABILITY%20is:open%20is:issue) |
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,13 +35,6 @@ The simplest way to report a vulnerability is to email the [epispot package auth
 
 Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages. If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
 
-```text
-sec   rsa3072/25B6A3ACE2E9FA1C 2021-07-30 [SC]
-      6B3C84252163F3BF00AB8CC125B6A3ACE2E9FA1C
-uid                 [ultimate] epispot (This is epispot's official GPG key for security vulnerability submissions.) 
-<dev.quantum9innovation@gmail.com>
-ssb   rsa3072/C85634FF0F7A1E8A 2021-07-30 [E]
-```
 
 Encrypt your message with the following GPG key block:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,6 @@ The simplest way to report a vulnerability is to email the [epispot package auth
 
 #### I want to use a GPG key
 
-**Note:** Please contact us in a separate email for the passphrase to the key shown below.
 
 Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages (this is in line with GitHub's Bug Bounty program, which follows a similar philosophy). If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,6 @@ The simplest way to report a vulnerability is to email the [epispot package auth
 
 #### I want to use a GPG key
 
-
 Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages (this is in line with GitHub's Bug Bounty program, which follows a similar philosophy). If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
 
 ```text

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,92 @@ The following versions will receive regular security updates:
 
 The epispot team works as hard as possible to keep code clear of any vulnerabilities. Our steps include extensive CodeQL analysis, third-party open-source code analysis from tools like DeepSource, and heavy unit testing. However, vulnerabilities will inevitably arise. If you see or suspect a vulnerability, epispot will fix it as fast as possible.
 
-### Here's what to do if you've found a vulnerability:
+### A note on disclosure:
 
-1. Open an issue and **@mention** a maintainer
-2. Title the issue "VULNERABILITY" but do not describe the vulnerability in the issue itself
-3. You will receive further instructions after completing (2)
+The entire epispot organization follows [Google's OSS Vulnerability Guide](https://github.com/google/oss-vulnerability-guide) and is committed to eliminating *any* vulnerabilities in our source code. Per [Google's guidelines](https://github.com/google/oss-vulnerability-guide/blob/main/guide.md#response-process), we will disclose any vulnerabilities we find within 90 days of their discovery.
+
+### If you've found a vulnerability:
+
+#### What not to do
+
+**Do not** create an issue, discussion, or any other public notice on the GitHub repository. Please also do not mention the vulnerability publicly in any other projects or channels (that includes official epispot projects as well).
+
+#### I don't have a GitHub account
+
+The simplest way to report a vulnerability is to email the [epispot package authors](https://pypi.org/project/epispot) directly with your concern. The current epispot package author is @quantum9innovation. Send your emails to dev.quantum9innovation@gmail.com and we'll respond as soon as possible. Please include `security`[*](#additional-notes) in the subject line or body of your email so that we can quickly identify the issue.
+
+#### I want to use a GPG key
+
+Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages. If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
+
+```text
+sec   rsa3072/25B6A3ACE2E9FA1C 2021-07-30 [SC]
+      6B3C84252163F3BF00AB8CC125B6A3ACE2E9FA1C
+uid                 [ultimate] epispot (This is epispot's official GPG key for security vulnerability submissions.) 
+<dev.quantum9innovation@gmail.com>
+ssb   rsa3072/C85634FF0F7A1E8A 2021-07-30 [E]
+```
+
+Encrypt your message with the following GPG key block:
+
+```text
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQGNBGEEkL0BDADKtW4dGeck35CPbRVAWaeqEa7f05kegwyoDoJ01vt6yJF9Y7Hj
+u7BwRDayxDS1WhtODMel/044Zirgpvx9e4VUn1SOfnEGm7Z/qMU3ETbxF9Uw6UXH
+t6RsGhmbDor7CgNpXC/YGP2R3yDsva6KTkt4/BiHsW8Mz9gMCv/BWA0ZSTf7dcIA
+paAG2sfUTIDGaHFAVoimwRNbmp5gk92YveHlsm0+fSr50hQAo6/Uv/DzEzCCcr9s
+HBXodwMCgZVY6atFDvlAGy6QFxTXY4YhdI6/Fjg1EXyEBhBk83M3lErqBAJZGl77
+riNiKxXCloPP44qnXLTywF2WZkiDlROX5cooo0HjpmREHasfEyFsTJlpLTo3R7FO
+VMqgP80xwowj2KAm5I5XjddNbqketJKj60C1y6xBcnFhraUTBw5ivtfLZZgJ50ak
+J5BpHNNSyRFwqrqN1dZOneBYjNIXxYX9eWkf2CWETkpdoacrV50z7wxu8zK5k/uE
+t+Zwmr+nKyMviBcAEQEAAbR3ZXBpc3BvdCAoVGhpcyBpcyBlcGlzcG90J3Mgb2Zm
+aWNpYWwgR1BHIGtleSBmb3Igc2VjdXJpdHkgdnVsbmVyYWJpbGl0eSBzdWJtaXNz
+aW9ucy4pIDxkZXYucXVhbnR1bTlpbm5vdmF0aW9uQGdtYWlsLmNvbT6JAc4EEwEK
+ADgWIQRrPIQlIWPzvwCrjMEltqOs4un6HAUCYQSQvQIbAwULCQgHAgYVCgkICwIE
+FgIDAQIeAQIXgAAKCRAltqOs4un6HPfdC/0XMVtCD+Bg57bLZAtgN//JHXeEXKSq
+LZCdnmd35bg3bBj1ba5pQgWHbN+HigeH7D06jTsxsmu74+ZbE2r+ZKwFDy3tHmxq
+SoZLqCLdYaL/XueuD20y8CloHzF65g3qdx2aeSYH+iZv2E95V0UGi7XBvmaW81PU
+ZVyZBUTRqPI/QxOK7bqF+QulAeV5JTU8lysrczhHRjuHDL6eB7csLBgfScbKy5g7
+TKUrEHj8WUH48wSOaXjfICUaxfPU15b+kM9BaDxu17kWVxWFp00Xqw9bbUuzky3u
+xXw3Z7eXTrEpiJMfJBqVYTfsbEyU9ULzBEPVY/LDg5wVhTFCYUP2sgTbCtXwhY1e
+GWYD/hMwW2UbGDded9orroIVVvnWv0t9rWGFj5RMF1F7a26afH/22xNeJfXmKmHw
+s8ve8+gpPr0RnBW+rbCr26AjpNAEYPnH/W8dGJ60JFqSyJJH1ljCZYQ4gFO8eNgk
+YogQmM7Tqc2CAOVVCNEjT8BPuhoYf0ECfPW5AY0EYQSQvQEMAOI/4c8T8T31ylVl
+NZdgUtxEu2JX/2cQX7r9ENc5Bjg5h7mJUm9bpWztre4RpAwnxluRN57zx6CCm7jK
+pq5eZLUzAwzpNzCSjr7Y1zrPRHd9+1DtZi3lvaAzmxJITM9YsAbVbIRxilWswv8f
+vq83AZW871YG/WZCoOPk/K7CwMSrjN3hjkGu2HuFmHnI6egX+z7nLMhzcNxrM6CJ
+lKMxu9a55lNvyy2OpyUIgTBOzq58MEYjxlnFizy3DcU2Vgpw6vk/0q3dRP1kFNB3
+a5f8Ox3PBwrQZuQ7XfFfpYG/u9xnviZqfJ1QJiv4QaMI7uCWAVFUWRhP+TLIKzIo
+S/ToWty0KE+gcQNoVBsBafsp7TlrveVNqZOVLIKkZSD1yWRqgbYcXCcV/BlSlVu1
+aZVS8tSssKHj6/epLBFtyH4SodWGONFgPZieXoWKcek+ay33YUeafWNlat/7wcH6
+lGXsL8gMWPyVcJYWYs9CQUPNv5nBRyv+soZseM94JtyawxMeswARAQABiQG2BBgB
+CgAgFiEEazyEJSFj878Aq4zBJbajrOLp+hwFAmEEkL0CGwwACgkQJbajrOLp+hx1
+fQv/dZO6mUBjm7ARGoquG5PcQSGtczQDZtKUSOcTxDklJNmaT6Fe2QJfXaRPJpZL
+561u8w8PjPMnPpqI8v/k3MgcnhS5RlJFCAXDx3tOaNDylYzVtXCGhQFvoDEFZiav
+M1ygX/1+QxCgrbJ/rt7kj1VqPDsr6foFBr+msA8U4+rohB1v4qwPBV0qyZlv3XcP
+FnfpSqAEXqiNRAi+F2fJsmsuSq7Y3mi68+3yAYw9ZUVNfnzorG1MEUrhO28orbFy
+jC3WoNHUpwYP+8dhDhfbGz68EDUMngS9VWTKiw7QB+zwU8WcQDJaSBk3rdqF6zwX
+Afbpo3eRhHkpynJdQ25o1tO9s42QN128kvCKVgSre+6nFYKO+HGaQ4RS2ctBDuUy
+5IHiwTH4gX3qKswK2RkNQlL6XzKDQ3nzt2V+k0ac8fghMo78g+R1TJLDIOk1lTi/
+/SWIOooCnPOjS/54TrTuh6yP0ECRKDyEzpwashwF2A0ZhoK14PWVI8NGylRpArs0
+K0Ou
+=NenA
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+Please contact us in a separate email for the passphrase to the above key.
+
+#### I have a GitHub account and ...
+
+##### I don't want to collaborate on a patch
+
+That's completely fine. Simply email us (encrypted or not) and we'll get back to you as soon as possible with our progress.
+
+##### I want to work on the patch
+
+In your email, please include your GitHub username so that we can share with you an invitation to the patch project. The invitation will be to a private GitHub repository that is a fork of the main one. We'll also add you as a collaborator on any public advisories that we will disclose after the patch is committed.
+
+#### Additional Notes
+
+*The word `vulnerability` will also suffice.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,10 +33,9 @@ The simplest way to report a vulnerability is to email the [epispot package auth
 
 #### I want to use a GPG key
 
-Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages. If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
+**Note:** Please contact us in a separate email for the passphrase to the key shown below.
 
-
-Encrypt your message with the following GPG key block:
+Please note that we will rarely reply to your email using a GPG key unless it poses a threat to other users and/or packages (this is in line with GitHub's Bug Bounty program, which follows a similar philosophy). If you feel that it is necessary to use a GPG key or want to conceal confidential information, our key fingerprint is:
 
 ```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -83,8 +82,6 @@ K0Ou
 =NenA
 -----END PGP PUBLIC KEY BLOCK-----
 ```
-
-Please contact us in a separate email for the passphrase to the above key.
 
 #### I have a GitHub account and ...
 

--- a/setup-nightly.py
+++ b/setup-nightly.py
@@ -1,34 +1,35 @@
 import setuptools
 
-with open("README-nightly.md", "r") as fh:
+with open('README-nightly.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="epispot-nightly",
-    version="3.0.0-alpha-2",
-    author="quantum9innovation",
-    description="The nightly version of the epispot package.",
+    name='epispot-nightly',
+    version='3.0.0-alpha-2',
+    author='quantum9innovation',
+    author_email = 'dev.quantum9innovation@gmail.com',
+    description='The nightly version of the epispot package.',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://epispot.github.io",
+    long_description_content_type='text/markdown',
+    url='https://epispot.github.io',
     project_urls={
-        "Repository": "https://github.com/epispot/epispot",
-        "Changelog": "https://github.com/epispot/epispot/tree/master/CHANGELOG.md",
-        "Bug Tracker": "https://github.com/epispot/epispot/issues",
-        "Documentation": "https://epispot.github.io/epispot",
-        "Code Coverage": "https://app.codecov.io/gh/epispot/epispot"
+        'Repository': 'https://github.com/epispot/epispot',
+        'Changelog': 'https://github.com/epispot/epispot/tree/master/CHANGELOG.md',
+        'Bug Tracker': 'https://github.com/epispot/epispot/issues',
+        'Documentation': 'https://epispot.github.io/epispot',
+        'Code Coverage': 'https://app.codecov.io/gh/epispot/epispot'
     },
     packages=setuptools.find_packages('epispot/'),
     scripts=['bin/epispot'],
     classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Healthcare Industry",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering",
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Healthcare Industry',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering',
     ],
     python_requires='>=3.7',
     install_requires=[

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = epispot
 author = quantum9innovation
+author_email = dev.quantum9innovation@gmail.com
 description = A tool for modeling infectious diseases.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,34 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="epispot",
-    version="2.1.1",
-    author="quantum9innovation",
-    description="A tool for modeling infectious diseases.",
+    name='epispot',
+    version='2.1.1',
+    author='quantum9innovation',
+    author_email='dev.quantum9innovation@gmail.com',
+    description='A tool for modeling infectious diseases.',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://epispot.github.io",
+    long_description_content_type='text/markdown',
+    url='https://epispot.github.io',
     project_urls={
-        "Repository": "https://github.com/epispot/epispot",
-        "Changelog": "https://github.com/epispot/epispot/tree/master/CHANGELOG.md",
-        "Bug Tracker": "https://github.com/epispot/epispot/issues",
-        "Documentation": "https://epispot.github.io/epispot",
-        "Code Coverage": "https://app.codecov.io/gh/epispot/epispot"
+        'Repository': 'https://github.com/epispot/epispot',
+        'Changelog': 'https://github.com/epispot/epispot/tree/master/CHANGELOG.md',
+        'Bug Tracker': 'https://github.com/epispot/epispot/issues',
+        'Documentation': 'https://epispot.github.io/epispot',
+        'Code Coverage': 'https://app.codecov.io/gh/epispot/epispot'
     },
     packages=setuptools.find_packages('epispot/'),
     classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Healthcare Industry",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering",
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Healthcare Industry',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering',
     ],
     python_requires='>=3.6',
     install_requires=['matplotlib', 'numpy', ],


### PR DESCRIPTION
This is the first major revision of our SECURITY.md document, and it's designed to meet our organization-wide commitment to better security. You can view the new document [here](https://github.com/epispot/epispot/blob/2adbdacaa19c43dc35ed40dbd8cbd1d3cb061e40/SECURITY.md).

## Changelist:
- SECURITY.md
    - Include more detailed instructions on the vulnerability disclosure process
    - Remove issue creation as a way to expose a vulnerability
    - Add emails and GPG keys to our vulnerability submission options
- Remove 'known vulnerabilities' badge (cannot be tracked anymore) from README-nightly.md
- setup.py, setup.cfg, setup-nightly.py
    - Add `author_email`
- Make @Quantalabs a co-owner of the security policy on .github/CODEOWNERS

## Additional Notes

This PR adds @Quantalabs as a code owner to SECURITY.md, and as such @Quantalabs will be responsible for the review process.