### PR TITLE
Fix failing docs from #113

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         pip install pdoc3


### PR DESCRIPTION
## Known Issues
Fixes Python version on docs workflow, which was Python 3.10; however, this was recognized as Python 3.1 in GitHub Actions. The quotes around it fix this problem.

## Code Breakdown
- docs.yml
    - Python version fix

## Additional Information
This is required for release of v3a3.
