### PR TITLE
Remove Python 3.7 from build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'


### PR DESCRIPTION
# Pull Request Template
For Issue #138, #139
___

## New Feature
Removes python 3.7 from all testing workflows.

## Known Issues
#139 and #138 state that python 3.7 must be deprecated, along with the merge of #137, which introduces the new numpy version, which deprecates python 3.7. 

## Code Breakdown
- Remove 3.7 from `.github/workflows/build.yml`

Closes #139 
